### PR TITLE
Small change in demo example, TF name is incorrect

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Once you have installed pyjaspar, you can create jaspardb class object:
     YY1
 
     #Fetch motifs by TF name
-    >>> motifs = jdb_obj.fetch_motifs_by_name('KFL4')
+    >>> motifs = jdb_obj.fetch_motifs_by_name('KLF4')
     >>> print(len(motifs))
     1
 


### PR DESCRIPTION
Note the TF is KLF4, not KFL4:

https://jaspar.elixir.no/search?q=KLF4&collection=all&tax_group=all&tax_id=all&type=all&class=all&family=all&version=all