### PR TITLE
Add species names to motif objects

### DIFF
--- a/docs/guide/core-api.md
+++ b/docs/guide/core-api.md
@@ -108,6 +108,7 @@ print(motif.name)        # YY1
 # Annotations
 print(motif.collection)  # CORE
 print(motif.species)     # ['9606']
+print(motif.species_name) # ['Homo sapiens']
 print(motif.tf_class)    # ['C2H2 zinc finger factors']
 print(motif.tf_family)   # ['More than 3 adjacent zinc fingers']
 print(motif.tax_group)   # vertebrates

--- a/src/pyjaspar/db.py
+++ b/src/pyjaspar/db.py
@@ -322,6 +322,7 @@ class JasparDB:
         # Fetch species
         cur.execute("SELECT TAX_ID FROM MATRIX_SPECIES WHERE ID = ?", (int_id,))
         motif.species = [row[0] for row in cur.fetchall()]
+        motif.species_name = self._resolve_species_names(motif.species)
 
         # Fetch protein accession numbers
         cur.execute(
@@ -357,6 +358,21 @@ class JasparDB:
         motif.tf_class = tf_class
 
         return motif
+
+    def _resolve_species_names(self, tax_ids: list[str]) -> list[str]:
+        """Resolve taxonomy IDs to species names using the bundled TAX table."""
+        if not tax_ids:
+            return []
+
+        cur = self._conn.cursor()
+        placeholders = ", ".join("?" for _ in tax_ids)
+        cur.execute(
+            f"SELECT TAX_ID, SPECIES FROM TAX WHERE TAX_ID IN ({placeholders})",
+            tax_ids,
+        )
+        names_by_tax_id = {str(row[0]): row[1] for row in cur.fetchall()}
+
+        return [names_by_tax_id.get(tax_id, tax_id) for tax_id in tax_ids]
 
     def _fetch_counts_matrix(self, int_id: int) -> GenericPositionMatrix:
         """Fetch the counts matrix from the JASPAR DB by internal ID."""

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -58,6 +58,11 @@ def test_fetch_motif_by_id_returns_motif(jdb_2026):
     assert isinstance(motif, Motif)
 
 
+def test_fetch_motif_by_id_resolves_species_name(sample_motif):
+    assert sample_motif.species == ["3702"]
+    assert sample_motif.species_name == ["Arabidopsis thaliana"]
+
+
 def test_fetch_motif_by_id_nonexistent_returns_none(jdb_2026):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")


### PR DESCRIPTION
## Summary

`motif.species` currently only exposes raw NCBI taxonomy IDs (e.g. `['9606']`), even though the bundled SQLite already ships a `TAX` table mapping taxid → species name. This adds `motif.species_name` to surface the resolved name directly, so callers don't need to hand-maintain their own taxid lookup.

- Falls back to the raw taxid string if a match isn't found in `TAX`, rather than raising.
- Applies to all fetch paths (`fetch_motif_by_id`, `fetch_motifs`, `fetch_motifs_by_name`) since they all funnel through the same internal motif-building method.

## Test plan

- [x] New unit test (`test_fetch_motif_by_id_resolves_species_name`) using the existing `sample_motif` fixture
- [x] `pytest tests/test_db.py` passes (15/15)
- [x] `ruff check` / `ruff format --check` clean on changed files
