### PR TITLE
Add get_collections() to list available JASPAR collections

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -182,6 +182,16 @@ pyjaspar releases
 pyjaspar releases --latest
 ```
 
+### collections
+
+List JASPAR collections available in a release. The set of collections
+varies by release (e.g. `CORE` and `UNVALIDATED` only from 2022 onward).
+
+```bash
+pyjaspar collections
+pyjaspar collections -r 2020
+```
+
 ### cite
 
 Show citation information.

--- a/docs/guide/core-api.md
+++ b/docs/guide/core-api.md
@@ -139,6 +139,16 @@ print(releases)
 #  'JASPAR2018', 'JASPAR2016', 'JASPAR2014']
 ```
 
+## Available collections
+
+The set of collections varies by release:
+
+```python
+collections = jdb.get_collections()
+print(collections)
+# ['CORE', 'UNVALIDATED']
+```
+
 ## Cross-release comparison
 
 ```python

--- a/src/pyjaspar/cli/main.py
+++ b/src/pyjaspar/cli/main.py
@@ -38,7 +38,7 @@ click.rich_click.COMMAND_GROUPS = {
         },
         {
             "name": "General commands",
-            "commands": ["releases", "cite"],
+            "commands": ["releases", "collections", "cite"],
         },
     ]
 }
@@ -344,6 +344,27 @@ def releases(latest: bool) -> None:
     else:
         for release in jaspar_releases:
             click.echo(release)
+
+
+@cli.command("collections")
+@click.option(
+    "-r",
+    "--release",
+    default=_LATEST_YEAR,
+    show_default=True,
+    type=click.Choice(_RELEASE_YEARS, case_sensitive=False),
+    help="JASPAR release year",
+)
+def collections(release: str) -> None:
+    """Get JASPAR collections available in a release.
+
+    CORE profiles are curated with orthogonal supporting evidence.
+    UNVALIDATED profiles are computationally sound but not yet
+    independently validated.
+    """
+    jdb = JasparDB(f"JASPAR{release}")
+    for collection in jdb.get_collections():
+        click.echo(collection)
 
 
 @cli.command("cite")

--- a/src/pyjaspar/cli/main.py
+++ b/src/pyjaspar/cli/main.py
@@ -362,9 +362,9 @@ def collections(release: str) -> None:
     UNVALIDATED profiles are computationally sound but not yet
     independently validated.
     """
-    jdb = JasparDB(f"JASPAR{release}")
-    for collection in jdb.get_collections():
-        click.echo(collection)
+    with JasparDB(f"JASPAR{release}") as jdb:
+        for collection in jdb.get_collections():
+            click.echo(collection)
 
 
 @cli.command("cite")

--- a/src/pyjaspar/db.py
+++ b/src/pyjaspar/db.py
@@ -128,6 +128,23 @@ class JasparDB:
         """
         return list(jaspar_releases.keys())
 
+    def get_collections(self) -> list[str]:
+        """Return the JASPAR collections present in the current release.
+
+        The set of collections varies by release. Recent releases (2022+)
+        use `CORE` (curated, non-redundant profiles with orthogonal
+        supporting evidence) and `UNVALIDATED` (computationally sound
+        profiles awaiting orthogonal support). Older releases also include
+        collections such as `CNE`, `FAM`, `PBM`, `PBM_HLH`, `PBM_HOMEO`,
+        `PHYLOFACTS`, `POLII`, and `SPLICE`.
+
+        Returns:
+            A sorted list of collection names.
+        """
+        cur = self._conn.cursor()
+        cur.execute("SELECT DISTINCT COLLECTION FROM MATRIX ORDER BY COLLECTION")
+        return [row[0] for row in cur.fetchall()]
+
     def fetch_motif_by_id(self, id: str) -> Motif | None:
         """Fetch a single JASPAR motif by its matrix ID.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,23 @@ def test_releases_latest():
     assert "JASPAR2026" in result.output
 
 
+# --- collections ---
+
+
+def test_collections():
+    result = CliRunner().invoke(cli, ["collections"])
+    assert result.exit_code == 0
+    assert "CORE" in result.output
+    assert "UNVALIDATED" in result.output
+
+
+def test_collections_release():
+    result = CliRunner().invoke(cli, ["collections", "-r", "2020"])
+    assert result.exit_code == 0
+    assert "CORE" in result.output
+    assert "PHYLOFACTS" in result.output
+
+
 # --- motif-by-id ---
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -99,3 +99,9 @@ def test_get_releases():
     assert len(releases) == 7
     assert releases[0] == "JASPAR2026"
     db.close()
+
+
+def test_get_collections():
+    db = JasparDB()
+    assert db.get_collections() == ["CORE", "UNVALIDATED"]
+    db.close()


### PR DESCRIPTION
## Summary

JASPAR groups its motif profiles into named `COLLECTION`s such as `CORE` and `UNVALIDATED`, reflecting curation status ([JASPAR docs](https://jaspar.elixir.no/docs/)). `CORE` profiles are manually curated with orthogonal supporting evidence, while `UNVALIDATED` profiles (introduced in the 2020 release) are computationally sound but not yet independently validated. `fetch_motifs()` already supports filtering by `collection`, but the set of valid values isn't fixed. It varies by release: collections like `CNE`, `FAM`, `PBM`, and `PHYLOFACTS` existed before 2022 and were later consolidated down to just `CORE` and `UNVALIDATED`. Nothing in the package currently surfaces what those values actually are for a given release.

This continues the same "strengthen metadata accessibility" effort as #7 (`species_name`). Instead of requiring users to already know a release's collection scheme, `JasparDB.get_collections()` (plus a `pyjaspar collections` CLI command) lets them discover it directly from the bundled SQLite.

- `get_collections()` returns `SELECT DISTINCT COLLECTION FROM MATRIX`, sorted.
- CLI command mirrors the existing `releases` command (`-r/--release` option, listed under "General commands").
- Docstring and help text explain what `CORE` and `UNVALIDATED` mean, per JASPAR's own docs.

## Test plan

- [x] New unit test (`test_get_collections`) in `test_db.py`
- [x] New CLI tests (`test_collections`, `test_collections_release`) in `test_cli.py`
- [x] `pytest` passes (36/36 across `test_db.py` and `test_cli.py`)
- [x] `ruff check` / `ruff format --check` clean on changed files
- [x] Manually verified `pyjaspar collections` / `pyjaspar collections -r 2020` output and `pyjaspar --help` listing
